### PR TITLE
Update lab5-ja.ipynb

### DIFF
--- a/content/lab_5/lab5-ja.ipynb
+++ b/content/lab_5/lab5-ja.ipynb
@@ -1236,7 +1236,7 @@
     "# Probability for a single CX gate\n",
     "p1 = 0.01\n",
     "# Probability that there is an error after 2 CX gates (going through stabilizer)\n",
-    "p2 = p1 * (1 - p1) + (1 - p1) * p\n",
+    "p2 = p1 * (1 - p1) + (1 - p1) * p1\n",
     "# Probability that the stabilizer shows something wrong even though it is correct\n",
     "p3 = p1 * p1 + (1 - p1) * (1 - p1) * p1\n",
     "\n",


### PR DESCRIPTION
Fixed the typo: from "p2 = p1 * (1 - p1) + (1 - p1) * p" to "p2 = p1 * (1 - p1) + (1 - p1) * p1".